### PR TITLE
Export ParseOptions type

### DIFF
--- a/.changeset/fast-tools-play.md
+++ b/.changeset/fast-tools-play.md
@@ -1,0 +1,5 @@
+---
+"@badrap/valita": patch
+---
+
+export `ParseOptions` type

--- a/src/index.ts
+++ b/src/index.ts
@@ -461,7 +461,7 @@ const FLAG_MISSING_VALUE = 1 << 2;
 export type Infer<T extends AbstractType> =
   T extends AbstractType<infer I> ? I : never;
 
-type ParseOptions = {
+export type ParseOptions = {
   mode?: "passthrough" | "strict" | "strip";
 };
 


### PR DESCRIPTION
useful when creating a set of validators that all should share the same mode.